### PR TITLE
Fix error: Cannot use object as array in /leafs/exception/src/Exceptions/Inspector.php:219

### DIFF
--- a/src/Exceptions/Inspector.php
+++ b/src/Exceptions/Inspector.php
@@ -216,8 +216,8 @@ class Inspector
                 $outerFrames = $this->frames;
                 $newFrames = clone $previousInspector->getFrames();
                 // I assume it will always be set, but let's be safe
-                if (isset($newFrames[0])) {
-                    $newFrames[0]->addComment(
+                if ( 0 < $newFrames->count() ) {
+                    $newFrames->offsetGet( 0 )->addComment(
                         $previousInspector->getExceptionMessage(),
                         'Exception message:'
                     );


### PR DESCRIPTION

<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## Description
An error occurs when generating an error:
Cannot use object as array in /leafs/exception/src/Exceptions/Inspector.php:219.
<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Related Issue
https://github.com/leafsphp/leaf/issues/142
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->