### PR TITLE
Http error codes for 404 and client Error - 400

### DIFF
--- a/src/Exception/General.php
+++ b/src/Exception/General.php
@@ -200,9 +200,12 @@ class General extends \Exception
      */
     public static function default404()
     {
-        echo static::errorMarkup(
-            '404',
-            '<p>The page you are looking for could not be found.</p>'
+        (new \Leaf\Http\Response())->exit(
+            static::errorMarkup(
+                '404',
+                '<p>The page you are looking for could not be found.</p>'
+            ),
+            404
         );
     }
 
@@ -211,9 +214,12 @@ class General extends \Exception
      */
     public static function csrf($error = null)
     {
-        echo static::errorMarkup(
-            'Invalid request',
-            "<p>$error</p>" ?? '<p>The page you are looking for has expired.</p>'
+        (new \Leaf\Http\Response())->exit(
+            static::errorMarkup(
+                'Invalid request',
+                "<p>$error</p>" ?? '<p>The page you are looking for has expired.</p>'
+            ),
+            400
         );
     }
 


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## Description

Normally when an  HTTP request is made a code denoting the status of the Request should be returned as part of the header, so the system (i.e. browser, console, etc) knows what's the status of the page without having to check the entire content of the page.

But for the issues below such code was not returned and since these exceptions were manually handled, `200` code was assumed by default, which kinda looks innocent by the way,  but it could cause some issues in some cases. i.e debugging, ajax requests, etc

For both functions `default404` and `csrf` , I've used `\Leaf\Http\Response()->exit` to extend the error handler and add the error code as part of the error response

<a href="https://ibb.co/mFJqPpZ"><img src="https://i.ibb.co/93nTdPK/Screenshot-2024-01-01-192257.png" alt="Screenshot-2024-01-01-192257" border="0"></a>

## Related Issue

- `\Leaf\Exception\General::default404();` was providing a custom error page for not found asset but did not return the HTTP error code 404

- `\Leaf\Exception\General::csrf();` was not returning any error code when CSRF had expired